### PR TITLE
Refactor loop code to be more async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ toml = "0.9.8"
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 default = "0.1.2"
+
+[profile.release]
+debug = true

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -3,6 +3,9 @@ use tokio::sync::mpsc;
 use crate::errors::EventError;
 use crate::routes::{RouteV4, NLRI};
 
+pub struct NeighborChannelWatcher {
+
+}
 #[derive(Debug)]
 pub struct NeighborChannel {
     pub tx: mpsc::Sender<ChannelMessage>,
@@ -10,7 +13,13 @@ pub struct NeighborChannel {
     //pub is_active: bool,
 }
 
+#[derive(Debug)]
+pub enum ChannelWatcherMessage {
+    MessageWaiting,
+    NoMessageWaiting
+}
 
+#[derive(Debug)]
 pub enum TCPChannelMessage {
     DropTCP
 }
@@ -23,9 +32,10 @@ pub enum ChannelMessage {
 }
 
 impl NeighborChannel {
-    pub async fn bring_up(&mut self) -> Result<(), EventError> {
+    pub async fn bring_up(&mut self, tx_channel_watcher: &mpsc::Sender<ChannelWatcherMessage>) -> Result<(), EventError> {
         //self.is_active = true;
         self.tx.send(ChannelMessage::NeighborUp).await.map_err(|_| EventError::ChannelDown)?;
+        tx_channel_watcher.send(ChannelWatcherMessage::MessageWaiting).await.map_err(|_| EventError::ChannelDown)?;
         Ok(())
     }
 
@@ -35,9 +45,10 @@ impl NeighborChannel {
     //     Ok(())
     // }
 
-    pub async fn send_route(&self, route: RouteV4) {
+    pub async fn send_route(&self, route: RouteV4, tx_channel_watcher: &mpsc::Sender<ChannelWatcherMessage>) {
         //if self.is_active {
-            self.tx.send(ChannelMessage::Route(route)).await.unwrap();
+        self.tx.send(ChannelMessage::Route(route)).await.unwrap();
+        tx_channel_watcher.send(ChannelWatcherMessage::MessageWaiting).await.unwrap();
         //}
     }
 
@@ -47,14 +58,16 @@ impl NeighborChannel {
         for route in routes {
             self.tx.send(ChannelMessage::Route(route.clone())).await.unwrap();
         }
-        
+        // does not need tx_channel_watcher because it's only used in run_recv_message_channel_loop in the proc, not in the neighbor.
+        //tx_channel_watcher.send(ChannelWatcherMessage::MessageWaiting).await.unwrap();
         //}
     }
 
 
-    pub async fn withdraw_route(&self, nlri_vec: Vec<NLRI>) {
+    pub async fn withdraw_route(&self, nlri_vec: Vec<NLRI>, tx_channel_watcher: &mpsc::Sender<ChannelWatcherMessage>) {
         //if self.is_active {
-            self.tx.send(ChannelMessage::WithdrawRoute(nlri_vec)).await.unwrap();
+        self.tx.send(ChannelMessage::WithdrawRoute(nlri_vec)).await.unwrap();
+        tx_channel_watcher.send(ChannelWatcherMessage::MessageWaiting).await.unwrap();
         //}
     }
 
@@ -68,6 +81,8 @@ impl NeighborChannel {
 
     pub fn send_tcp_conn_to_neighbor(&self, tcp_stream: TcpStream) -> Result<(), EventError> {
         //println!("executing send_tcp_conn_to_neighbor");
+        // This func doesn't need ChannelWatcherMessage because it runs only in run_process_loop.
+        // ChannelWatcherMessage is really for sending an unlock signal from neighbor to proc loop.
         self.tx.try_send(ChannelMessage::TcpEstablished(tcp_stream)).map_err(|_| EventError::ChannelDown)
     }
 }

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -65,6 +65,7 @@ pub struct Neighbor {
     // TODO adj-rib-out filters routes before they are sent to neighbor, generate event to send update
     pub adj_rib_out: HashMap<NLRI, RouteV4>,
     pub channel: NeighborChannel,
+    pub tx_channel_watcher: Sender<ChannelWatcherMessage>,
     //pub tcp_read_stream: Option<OwnedReadHalf>,
     pub tcp_write_stream: Option<OwnedWriteHalf>,
     pub negotiated_capabilities: Option<Vec<Capability>>,
@@ -76,7 +77,7 @@ pub async fn run_timer_loop(neighbor_arc: Arc<Mutex<Neighbor>>, peer_ip: Ipv4Add
         loop {
             { neighbor_arc.lock().await.check_timers_and_generate_events().await; }
             // sleep outside of this so we don't hold a mutex
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_millis(1000)).await;
         }
     });
 }
@@ -126,7 +127,7 @@ impl Neighbor {
         Ok(())
     }
 
-    pub fn new(ip: Ipv4Addr, as_num: AS, keepalive_time_sec: u16, hold_time_sec: u16, peer_type: PeerType, settings: GlobalSettings, neighbor_channel: NeighborChannel) -> Result<Neighbor, MessageError> {
+    pub fn new(ip: Ipv4Addr, as_num: AS, keepalive_time_sec: u16, hold_time_sec: u16, peer_type: PeerType, settings: GlobalSettings, neighbor_channel: NeighborChannel, tx_channel_watcher: Sender<ChannelWatcherMessage>) -> Result<Neighbor, MessageError> {
         if keepalive_time_sec < 1 {
             return Err(MessageError::HelloTimeLessThanOne);
         }
@@ -153,6 +154,7 @@ impl Neighbor {
             adj_rib_in: HashMap::new(),
             adj_rib_out: HashMap::new(),
             channel: neighbor_channel,
+            tx_channel_watcher,
             //tcp_read_stream: None,
             tcp_write_stream: None,
             negotiated_capabilities: None,
@@ -168,7 +170,7 @@ impl Neighbor {
                 // TODO get rid of this and handle it better, for now I just want to see the routes coming to the BGP proc loc_rib
             }
             
-            self.channel.withdraw_route(withdrawn_routes).await;
+            self.channel.withdraw_route(withdrawn_routes, &self.tx_channel_watcher).await;
             
             Ok(())
         }
@@ -248,7 +250,7 @@ impl Neighbor {
                 //self.routes_v4.push(rt);
                 self.adj_rib_in.insert(nlri.clone(), rt.clone());
                 // TODO get rid of this and handle it better, for now I just want to see the routes coming to the BGP proc loc_rib
-                self.channel.send_route(rt).await;
+                self.channel.send_route(rt, &self.tx_channel_watcher).await;
             }
             Ok(())
         }
@@ -933,7 +935,7 @@ impl Neighbor {
                         // TODO Need to confirm that we will always receive a Keepalive on neighbor coming up even if holdtime is 0
                         self.fsm.state = State::Established;
                         println!("Moving to {:#?}", self.fsm.state);
-                        self.channel.bring_up().await?;
+                        self.channel.bring_up(&self.tx_channel_watcher).await?;
                         Ok(())
                     },
                     Event::ConnectRetryTimerExpires | Event::DelayOpenTimerExpires | Event::IdleHoldTimerExpires |
@@ -1212,35 +1214,6 @@ impl Neighbor {
 
 
 
-    // pub async fn handle_open_message(&mut self, tcp_stream: &mut TcpStream, tsbuf: &Vec<u8>, bgp_proc: &mut BGPProcess) -> Result<(), BGPError> {
-    //     // TODO handle better, for now just accept the neighbor and mirror the capabilities for testing
-    //     // compare the open message params to configured neighbor
-    //     let received_open = extract_open_message(tsbuf)?;
-    //
-    //     //let peer_ip = get_neighbor_ipv4_address_from_stream(tcp_stream)?;
-    //
-    //     if self.is_established() {
-    //         return Err(NeighborError::NeighborAlreadyEstablished.into())
-    //     }
-    //
-    //
-    //     //let neighbor = bgp_proc.neighbors.get_mut(&peer_ip).ok_or_else(|| NeighborError::PeerIPNotRecognized)?;
-    //     let open_message = OpenMessage::new(BGPVersion::V4, bgp_proc.global_settings.my_as, self.fsm.hold_time, bgp_proc.global_settings.identifier, 0, None)?;
-    //     send_open(tcp_stream, open_message).await?;
-    //     send_keepalive(tcp_stream).await?;
-    //     //TODO handle this error so it doesn't return
-    //     self.set_hold_time(received_open.hold_time)?;
-    //     self.fsm.state = State::Established;
-    //
-    //     //add_neighbor_from_message(bgp_proc, &mut received_open, peer_ip, cn.hello_time, cn.hold_time)?;
-    //
-    //     // TODO REMOVE AFTER TESTING IT WORKS HERE
-    //     test_net_advertisements(bgp_proc, tcp_stream).await?;
-    //
-    //     Ok(())
-    //
-    // }
-
     pub async fn handle_update_message(&mut self, tsbuf: &Vec<u8>) -> Result<(), BGPError> {
         println!("Handling update message");
         if !self.is_established() {
@@ -1251,32 +1224,6 @@ impl Neighbor {
 
         Ok(())
     }
-
-
-    // pub async fn route_incoming_message_to_handler(&mut self, tcp_stream: &mut TcpStream, tsbuf: &Vec<u8>, bgp_proc: &mut BGPProcess) -> Result<(), BGPError> {
-    //     let message_type = parse_packet_type(&tsbuf)?;
-    //     println!("{}", message_type);
-    //     match message_type {
-    //         MessageType::Open => {
-    //             self.handle_open_message(tcp_stream, tsbuf, bgp_proc).await?
-    //         },
-    //         MessageType::Update => {
-    //             self.handle_update_message(tcp_stream, tsbuf, bgp_proc).await?
-    //         },
-    //         MessageType::Notification => {
-    //             crate::messages::notification::handle_notification_message(tcp_stream, tsbuf, bgp_proc).await?;
-    //         },
-    //         MessageType::Keepalive => {
-    //             handle_keepalive_message(tcp_stream).await?
-    //         },
-    //         MessageType::RouteRefresh => {
-    //             // TODO handle route refresh
-    //             crate::messages::route_refresh::handle_route_refresh_message(tcp_stream, tsbuf)?
-    //         }
-    //     }
-    //     Ok(())
-    // }
-
 
 
 
@@ -1475,7 +1422,6 @@ pub async fn run_neighbor_loop(mut tcp_stream: tokio::net::TcpStream, mut neighb
     // max bgp msg size should never exceed 4096
     // TODO determine if we want to honor the above rule or not, if not, how should we handle it
     let mut tsbuf: Vec<u8> = Vec::with_capacity(65536);
-    //let tcp_stream = ts;
 
     let (mut tcp_read, mut tcp_write) = tcp_stream.into_split();
     let mut tcp_read_stream: Option<OwnedReadHalf> = Some(tcp_read);
@@ -1528,16 +1474,7 @@ pub async fn run_neighbor_loop(mut tcp_stream: tokio::net::TcpStream, mut neighb
             }
         }
 
-        // the write half is moved inside the func, whereas the read half is returned here and move it into the correct var
-        // if let Some((new_tcp_read_stream, new_tcp_write_stream)) = neighbor_arc.lock().await.reestablish_neighbor_streams() {
-        //     println!("");
-        //     tcp_read_stream = Some(new_tcp_read_stream);
-        //
-        //     neighbor_arc.lock().await.generate_event(Event::TcpCRAcked);
-        // }
-
         neighbor_arc.lock().await.recv_routes_from_bgp_proc().await;
-        //recv_routes_from_bgp_proc(&neighbor_arc).await;
 
 
         tsbuf.clear();
@@ -1590,6 +1527,8 @@ pub async fn run_neighbor_loop(mut tcp_stream: tokio::net::TcpStream, mut neighb
                     },
                     Err(e) => {
                         if e.kind() == io::ErrorKind::WouldBlock {
+                            // Tested and this rarely fires so it's working as expected
+                            // println!("ErrorKind::WouldBlock in run_neighbor_loop");
                             continue;
                         }
                         else {

--- a/src/process.rs
+++ b/src/process.rs
@@ -9,7 +9,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::{Receiver, Sender};
 use crate::config::*;
 use crate::errors::*;
 use crate::finite_state_machine::events::Event;
@@ -17,7 +17,7 @@ use crate::messages::BGPVersion;
 use crate::utils::*;
 use crate::messages::update::AS::AS4;
 use crate::{neighbors, process};
-use crate::channels::{ChannelMessage, NeighborChannel};
+use crate::channels::{ChannelWatcherMessage, ChannelMessage, NeighborChannel};
 use crate::messages::update::{AsPath, AsPathSegment, AsPathSegmentType, LocalPref, NextHop, Origin, OriginType, AS};
 use crate::neighbors::{Neighbor, PeerType};
 use crate::routes::{RouteV4, NLRI};
@@ -221,8 +221,9 @@ impl BGPProcess {
         // init
         BGPProcess::populate_local_rib_from_config_arc(&bgp_proc_arc).await;
         let all_neighbors_channels_arc = BGPProcess::init_process_channels();
-        let mut all_neighbors = BGPProcess::populate_neighbors_from_config(&bgp_proc, &all_neighbors_channels_arc).await;
-        BGPProcess::run_recv_message_channel_loop(Arc::clone(&bgp_proc), Arc::clone(&all_neighbors_channels_arc)).await;
+        let (tx_channel_watcher, rx_channel_watcher) = mpsc::channel::<ChannelWatcherMessage>(1);
+        let mut all_neighbors = BGPProcess::populate_neighbors_from_config(&bgp_proc, &all_neighbors_channels_arc, tx_channel_watcher).await;
+        BGPProcess::run_recv_message_channel_loop(Arc::clone(&bgp_proc), Arc::clone(&all_neighbors_channels_arc), rx_channel_watcher).await;
         BGPProcess::generate_event_for_all_neighbors(&mut all_neighbors, Event::AutomaticStartWithPassiveTcpEstablishment).await;
         //
 
@@ -287,7 +288,7 @@ impl BGPProcess {
         }
     }
 
-    pub async fn populate_neighbors_from_config(bgp_proc_arc: &Arc<Mutex<BGPProcess>>, all_neighbors_channels_arc: &Arc<Mutex<HashMap<Ipv4Addr, NeighborChannel>>>) -> HashMap<Ipv4Addr, Neighbor> {
+    pub async fn populate_neighbors_from_config(bgp_proc_arc: &Arc<Mutex<BGPProcess>>, all_neighbors_channels_arc: &Arc<Mutex<HashMap<Ipv4Addr, NeighborChannel>>>, tx_channel_watcher: Sender<ChannelWatcherMessage>) -> HashMap<Ipv4Addr, Neighbor> {
         // This function is dual purpose, return all_neighbors (who we added tx and rx channels to) + add channels to all_neighbors_channels_arc (for us to tx and rx messages from neighbor)
         let bgp_proc = bgp_proc_arc.lock().await;
         let mut all_neighbors = HashMap::new();
@@ -320,7 +321,7 @@ impl BGPProcess {
                         all_neighbors_channels.insert(ip, neighbors_channels);
                     }
 
-                    match Neighbor::new(ip, AS::AS4(nc.as_num as u32), nc.hello_time, nc.hold_time, peer_type, global_settings.clone(), bgp_channel) {
+                    match Neighbor::new(ip, AS::AS4(nc.as_num as u32), nc.hello_time, nc.hold_time, peer_type, global_settings.clone(), bgp_channel, tx_channel_watcher.clone()) {
                         Ok(neighbor) => {
                             all_neighbors.insert(ip, neighbor);
                         },
@@ -352,62 +353,69 @@ impl BGPProcess {
 
 
 
-    pub async fn run_recv_message_channel_loop(bgp_proc_arc: Arc<Mutex<BGPProcess>>, mut all_neighbors_channels_arc: Arc<Mutex<HashMap<Ipv4Addr, NeighborChannel>>>) {
+    pub async fn run_recv_message_channel_loop(bgp_proc_arc: Arc<Mutex<BGPProcess>>, mut all_neighbors_channels_arc: Arc<Mutex<HashMap<Ipv4Addr, NeighborChannel>>>, rx_channel_watcher: Receiver<ChannelWatcherMessage>) {
+        // TODO need to refactor this so we don't loop to unlock the all_neighbors_channels_arc
+        // maybe pass a MessageReady event that we await on
+        // when at least one neighbor has a message, resume the task
         tokio::spawn( async move {
+            let mut watcher = rx_channel_watcher;
             loop {
-                let mut all_neighbors_channels = all_neighbors_channels_arc.lock().await;
-                // TODO check the channel and unlock the bgp Arc Mutex if we need to modify the loc_rib
-                for (neighbor_ip, route_channel) in &mut *all_neighbors_channels {
-                    while let Ok(msg) = route_channel.rx.try_recv() {
-                        match msg {
-                            ChannelMessage::Route(route) => {
-                                // TODO handle route here so that we go calc. best path and add it to the loc_rib
-                                // for now i will just test adding it to the bgp loc_rib
-                                // if an entry for the NLRI exists, add the route path too it don't overwrite
-                                {
-                                    let nlri = route.nlri.clone();
+                if let Some(ChannelWatcherMessage::MessageWaiting) = watcher.recv().await {
+                    let mut all_neighbors_channels = all_neighbors_channels_arc.lock().await;
+                    // TODO check the channel and unlock the bgp Arc Mutex if we need to modify the loc_rib
+                    for (neighbor_ip, route_channel) in &mut *all_neighbors_channels {
+                        while let Ok(msg) = route_channel.rx.try_recv() {
+                            match msg {
+                                ChannelMessage::Route(route) => {
+                                    // TODO handle route here so that we go calc. best path and add it to the loc_rib
+                                    // for now i will just test adding it to the bgp loc_rib
+                                    // if an entry for the NLRI exists, add the route path too it don't overwrite
+                                    {
+                                        let nlri = route.nlri.clone();
+                                        let mut bgp_proc = bgp_proc_arc.lock().await;
+                                        match bgp_proc.local_rib.get_mut(&nlri) {
+                                            Some(route_paths) => {
+                                                route_paths.push(route);
+                                            }
+                                            None => {
+                                                bgp_proc.local_rib.insert(nlri, vec![route]);
+                                            }
+                                        }
+                                        println!("Adding route to BGP local RIB");
+                                        println!("Current BGP local RIB is {:#?}", bgp_proc.local_rib);
+                                    }
+                                },
+                                ChannelMessage::WithdrawRoute(nlri_vec) => {
                                     let mut bgp_proc = bgp_proc_arc.lock().await;
-                                    match bgp_proc.local_rib.get_mut(&nlri) {
-                                       Some(route_paths) => {
-                                           route_paths.push(route);
-                                       }
-                                       None => {
-                                           bgp_proc.local_rib.insert(nlri, vec![route]);
-                                       }
+                                    for nlri in nlri_vec {
+                                        println!("Removing route from BGP local RIB");
+                                        if let None =  bgp_proc.local_rib.remove(&nlri) {
+                                            println!("Attempted to remove {:#?} from the BGP local RIB but was unable to find the route", nlri);
+                                        }
                                     }
-                                    println!("Adding route to BGP local RIB");
-                                    println!("Current BGP local RIB is {:#?}", bgp_proc.local_rib);
+                                    println!("Current BGP Local RIB is {:#?}", bgp_proc.local_rib);
                                 }
-                            },
-                            ChannelMessage::WithdrawRoute(nlri_vec) => {
-                                let mut bgp_proc = bgp_proc_arc.lock().await;
-                                for nlri in nlri_vec {
-                                    println!("Removing route from BGP local RIB");
-                                    if let None =  bgp_proc.local_rib.remove(&nlri) {
-                                        println!("Attempted to remove {:#?} from the BGP local RIB but was unable to find the route", nlri);
+                                // ChannelMessage::NeighborDown => {
+                                //     // prevent the BGP proc from using the TX channel until we get a NeighborUp
+                                // },
+                                ChannelMessage::NeighborUp => {
+                                    // Allow the BGP proc to send messages (routes) to the Neighbor task
+                                    let mut bgp_proc = bgp_proc_arc.lock().await;
+                                    for (_nlri, route_vec) in &bgp_proc.local_rib {
+                                        println!("Received ChannelMessage::NeighborUp, sending route_vec - {:#?}", route_vec);
+                                        route_channel.send_route_vec(route_vec).await;
                                     }
-                                }
-                                println!("Current BGP Local RIB is {:#?}", bgp_proc.local_rib);
-                            }
-                            // ChannelMessage::NeighborDown => {
-                            //     // prevent the BGP proc from using the TX channel until we get a NeighborUp
-                            // },
-                            ChannelMessage::NeighborUp => {
-                                // Allow the BGP proc to send messages (routes) to the Neighbor task
-                                let mut bgp_proc = bgp_proc_arc.lock().await;
-                                for (_nlri, route_vec) in &bgp_proc.local_rib {
-                                    println!("Received ChannelMessage::NeighborUp, sending route_vec - {:#?}", route_vec);
-                                    route_channel.send_route_vec(route_vec).await;
+
+                                },
+                                ChannelMessage::TcpEstablished(tcp_stream) => {
+                                    panic!("We should never get a NeighborChannel::TcpEstablished from Neighbor to BGP proc");
                                 }
 
-                            },
-                            ChannelMessage::TcpEstablished(tcp_stream) => {
-                                panic!("We should never get a NeighborChannel::TcpEstablished from Neighbor to BGP proc");
                             }
-
                         }
                     }
                 }
+
             }
         });
     }


### PR DESCRIPTION
Originally this branch was supposed to be about migrating to Tokio's Select!, but somehow I ended up profiling, lol. Did some profiling in intel vTUne and found the try_recf loops were still very expensive. Cut the CPU time from 90s to 50s by making run_recf_message_channel_loop truly async. run_event_loop is also similarly expensive, and I will work on that next. https://github.com/vektorprime/RustyBGP/pull/10